### PR TITLE
only be verbose in debug-mode

### DIFF
--- a/fastbill.1.2.php
+++ b/fastbill.1.2.php
@@ -101,7 +101,7 @@ class fastbill
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $bodyStr);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
-                curl_setopt($ch, CURLOPT_VERBOSE, 1);
+                curl_setopt($ch, CURLOPT_VERBOSE, ($this->debug ? 1 : 0));
 
                 $exec = curl_exec($ch);
 
@@ -124,4 +124,3 @@ class fastbill
         }
     }
 }
-?>


### PR DESCRIPTION
Thank you for making the access to the FastBill API easier with your library!

I guess it's better to be verbose only in debug-mode (to not get unwanted screen output).
And I removed the trailing `?>`.